### PR TITLE
Implement PR feedback and implicit ops

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -63,6 +63,8 @@ class half_t;
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(float val);
 KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(bool val);
+KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(double val);
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(short val);
@@ -81,6 +83,43 @@ half_t cast_to_half(unsigned long val);
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(unsigned long long val);
 
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, bool>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned short>::value, T>
+        cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
+    cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned long>::value, T>
+        cast_from_half(half_t);
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
+        cast_from_half(half_t);
+
 class half_t {
  public:
   using impl_type = HALF_IMPL_TYPE;
@@ -89,24 +128,38 @@ class half_t {
   impl_type val;
 
  public:
-  // Conversion operator for __half(bar) = half_t(foo)
   KOKKOS_FUNCTION
-  operator impl_type() const { return val; }
+  half_t() : val(0) {}
+
+  // Don't support implicit conversion back to impl_type.
+  // impl_type is a storage only type on host.
+  KOKKOS_FUNCTION
+  explicit operator impl_type() { return val; }
 
   KOKKOS_FUNCTION
-  explicit operator bool() const {
-    return static_cast<bool>(__half2float(val) == 0.0F);
-  }
-
+  half_t(impl_type rhs) : val(rhs) {}
   KOKKOS_FUNCTION
-  half_t(const half_t&) = default;
-
+  half_t(float rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  half_t(impl_type rhs = cast_to_half(0)) : val(rhs) {}
-
-  // Cast rhs to half for assignment to lhs of type half_t
-  template <class T>
-  KOKKOS_FUNCTION half_t(T rhs) : half_t(cast_to_half(rhs)) {}
+  half_t(bool rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(double rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(short rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(int rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(long rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(long long rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(unsigned short rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(unsigned int rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(unsigned long rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(unsigned long long rhs) : val(cast_to_half(rhs).val) {}
 
   // Unary operators
   KOKKOS_FUNCTION
@@ -227,54 +280,50 @@ class half_t {
 
   // Binary Arithmetic
   KOKKOS_FUNCTION
-  half_t operator+(half_t rhs) const {
-    half_t tmp = *this;
+  half_t friend operator+(half_t lhs, half_t rhs) {
 #ifdef __CUDA_ARCH__
-    tmp.val += rhs.val;
+    lhs.val += rhs.val;
 #else
-    tmp.val = __float2half(__half2float(tmp.val) + __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) + __half2float(rhs.val));
 #endif
-    return tmp;
+    return lhs;
   }
 
   KOKKOS_FUNCTION
-  half_t operator-(half_t rhs) const {
-    half_t tmp = *this;
+  half_t friend operator-(half_t lhs, half_t rhs) {
 #ifdef __CUDA_ARCH__
-    tmp.val -= rhs.val;
+    lhs.val -= rhs.val;
 #else
-    tmp.val = __float2half(__half2float(tmp.val) - __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) - __half2float(rhs.val));
 #endif
-    return tmp;
+    return lhs;
   }
 
   KOKKOS_FUNCTION
-  half_t operator*(half_t rhs) const {
-    half_t tmp = *this;
+  half_t friend operator*(half_t lhs, half_t rhs) {
 #ifdef __CUDA_ARCH__
-    tmp.val *= rhs.val;
+    lhs.val *= rhs.val;
 #else
-    tmp.val = __float2half(__half2float(tmp.val) * __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) * __half2float(rhs.val));
 #endif
-    return tmp;
+    return lhs;
   }
 
   KOKKOS_FUNCTION
-  half_t operator/(half_t rhs) const {
-    half_t tmp = *this;
+  half_t friend operator/(half_t lhs, half_t rhs) {
 #ifdef __CUDA_ARCH__
-    tmp.val /= rhs.val;
+    lhs.val /= rhs.val;
 #else
-    tmp.val = __float2half(__half2float(tmp.val) / __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) / __half2float(rhs.val));
 #endif
-    return tmp;
+    return lhs;
   }
 
   // Logical operators
   KOKKOS_FUNCTION
   bool operator!() const {
 #ifdef __CUDA_ARCH__
-    return !val;
+    return static_cast<bool>(!val);
 #else
     return !__half2float(val);
 #endif
@@ -284,7 +333,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator&&(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val && rhs.val;
+    return static_cast<bool>(val && rhs.val);
 #else
     return __half2float(val) && __half2float(rhs.val);
 #endif
@@ -294,7 +343,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator||(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val || rhs.val;
+    return static_cast<bool>(val || rhs.val);
 #else
     return __half2float(val) || __half2float(rhs.val);
 #endif
@@ -304,7 +353,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator==(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val == rhs.val;
+    return static_cast<bool>(val == rhs.val);
 #else
     return __half2float(val) == __half2float(rhs.val);
 #endif
@@ -313,7 +362,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator!=(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val != rhs.val;
+    return static_cast<bool>(val != rhs.val);
 #else
     return __half2float(val) != __half2float(rhs.val);
 #endif
@@ -322,7 +371,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator<(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val < rhs.val;
+    return static_cast<bool>(val < rhs.val);
 #else
     return __half2float(val) < __half2float(rhs.val);
 #endif
@@ -331,7 +380,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator>(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val > rhs.val;
+    return static_cast<bool>(val > rhs.val);
 #else
     return __half2float(val) > __half2float(rhs.val);
 #endif
@@ -340,7 +389,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator<=(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val <= rhs.val;
+    return static_cast<bool>(val <= rhs.val);
 #else
     return __half2float(val) <= __half2float(rhs.val);
 #endif
@@ -349,7 +398,7 @@ class half_t {
   KOKKOS_FUNCTION
   bool operator>=(half_t rhs) const {
 #ifdef __CUDA_ARCH__
-    return val >= rhs.val;
+    return static_cast<bool>(val >= rhs.val);
 #else
     return __half2float(val) >= __half2float(rhs.val);
 #endif
@@ -367,65 +416,68 @@ KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(half_t val) { return val; }
 
 KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(float val) { return __float2half(val); }
+half_t cast_to_half(float val) { return half_t(__float2half(val)); }
+
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(bool val) { return cast_to_half(static_cast<float>(val)); }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(double val) {
   // double2half was only introduced in CUDA 11 too
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(short val) {
 #ifdef __CUDA_ARCH__
-  return __short2half_rn(val);
+  return half_t(__short2half_rn(val));
 #else
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 #endif
 }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(unsigned short val) {
 #ifdef __CUDA_ARCH__
-  return __ushort2half_rn(val);
+  return half_t(__ushort2half_rn(val));
 #else
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 #endif
 }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(int val) {
 #ifdef __CUDA_ARCH__
-  return __int2half_rn(val);
+  return half_t(__int2half_rn(val));
 #else
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 #endif
 }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(unsigned int val) {
 #ifdef __CUDA_ARCH__
-  return __uint2half_rn(val);
+  return half_t(__uint2half_rn(val));
 #else
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 #endif
 }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(long long val) {
 #ifdef __CUDA_ARCH__
-  return __ll2half_rn(val);
+  return half_t(__ll2half_rn(val));
 #else
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 #endif
 }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(unsigned long long val) {
 #ifdef __CUDA_ARCH__
-  return __ull2half_rn(val);
+  return half_t(__ull2half_rn(val));
 #else
-  return __float2half(static_cast<float>(val));
+  return half_t(__float2half(static_cast<float>(val)));
 #endif
 }
 
@@ -442,22 +494,28 @@ half_t cast_to_half(unsigned long val) {
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
 cast_from_half(half_t val) {
-  return __half2float(val);
+  return __half2float(half_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, bool>::value, T>
+cast_from_half(half_t val) {
+  return static_cast<T>(cast_from_half<float>(val));
 }
 
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
 cast_from_half(half_t val) {
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 }
 
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
 cast_from_half(half_t val) {
 #ifdef __CUDA_ARCH__
-  return __half2short_rz(val);
+  return __half2short_rz(half_t::impl_type(val));
 #else
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 #endif
 }
 
@@ -466,18 +524,18 @@ KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned short>::value, T>
     cast_from_half(half_t val) {
 #ifdef __CUDA_ARCH__
-  return __half2ushort_rz(val);
+  return __half2ushort_rz(half_t::impl_type(val));
 #else
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 #endif
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
 cast_from_half(half_t val) {
 #ifdef __CUDA_ARCH__
-  return __half2int_rz(val);
+  return __half2int_rz(half_t::impl_type(val));
 #else
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 #endif
 }
 
@@ -485,9 +543,9 @@ template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned>::value, T>
 cast_from_half(half_t val) {
 #ifdef __CUDA_ARCH__
-  return __half2uint_rz(val);
+  return __half2uint_rz(half_t::impl_type(val));
 #else
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 #endif
 }
 
@@ -495,9 +553,9 @@ template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
 cast_from_half(half_t val) {
 #ifdef __CUDA_ARCH__
-  return __half2ll_rz(val);
+  return __half2ll_rz(half_t::impl_type(val));
 #else
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 #endif
 }
 
@@ -506,9 +564,9 @@ KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
     cast_from_half(half_t val) {
 #ifdef __CUDA_ARCH__
-  return __half2ull_rz(val);
+  return __half2ull_rz(half_t::impl_type(val));
 #else
-  return static_cast<T>(__half2float(val));
+  return static_cast<T>(__half2float(half_t::impl_type(val)));
 #endif
 }
 

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -68,6 +68,8 @@ constexpr const bool half_is_float = true;
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(float val) { return half_t(val); }
 KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(bool val) { return half_t(val); }
+KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(double val) { return half_t(val); }
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(short val) { return half_t(val); }
@@ -90,15 +92,15 @@ half_t cast_to_half(unsigned long long val) { return half_t(val); }
 // Using an explicit list here too, since the other ones are explicit and for
 // example don't include char
 template <class T>
-KOKKOS_INLINE_FUNCTION typename std::enable_if<
-    std::is_same<T, float>::value || std::is_same<T, double>::value ||
-        std::is_same<T, short>::value ||
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    std::is_same<T, float>::value || std::is_same<T, bool>::value ||
+        std::is_same<T, double>::value || std::is_same<T, short>::value ||
         std::is_same<T, unsigned short>::value || std::is_same<T, int>::value ||
         std::is_same<T, unsigned int>::value || std::is_same<T, long>::value ||
         std::is_same<T, unsigned long>::value ||
         std::is_same<T, long long>::value ||
         std::is_same<T, unsigned long long>::value,
-    T>::type
+    T>
 cast_from_half(half_t val) {
   return T(val);
 }

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -64,14 +64,26 @@ enum OP_TESTS {
   PREFIX_DEC,
   POSTFIX_INC,
   POSTFIX_DEC,
-  CADD,
-  CSUB,
-  CMUL,
-  CDIV,
-  ADD,
-  SUB,
-  MUL,
-  DIV,
+  CADD_H_H,
+  CADD_H_S,
+  CSUB_H_H,
+  CSUB_H_S,
+  CMUL_H_H,
+  CMUL_H_S,
+  CDIV_H_H,
+  CDIV_H_S,
+  ADD_H_H,
+  ADD_H_S,
+  ADD_S_H,
+  SUB_H_H,
+  SUB_H_S,
+  SUB_S_H,
+  MUL_H_H,
+  MUL_H_S,
+  MUL_S_H,
+  DIV_H_H,
+  DIV_H_S,
+  DIV_S_H,
   NEG,
   AND,
   OR,
@@ -83,7 +95,7 @@ enum OP_TESTS {
   GE,
   TW,
   PASS_BY_REF,
-  AO___HALF,
+  AO_IMPL_HALF,
   AO_HALF_T,
   N_OP_TESTS
 };
@@ -156,44 +168,93 @@ struct Functor_TestHalfOperators {
 
     // if (h_lhs != tmp_lhs) {
     //  printf("tmp_lhs = %f, h_lhs = %f\n", __half2float(tmp_lhs),
-    //  __half2float(h_lhs)); Kokkos::abort("Error in half_t postfix operators");
+    //  __half2float(h_lhs)); Kokkos::abort("Error in half_t postfix
+    //  operators");
     //}
 
     tmp_lhs = h_lhs;
     tmp_lhs += h_rhs;
-    actual_lhs(CADD)   = cast_from_half<double>(tmp_lhs);
-    expected_lhs(CADD) = d_lhs;
-    expected_lhs(CADD) += d_rhs;
+    actual_lhs(CADD_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CADD_H_H) = d_lhs;
+    expected_lhs(CADD_H_H) += d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs += static_cast<float>(d_rhs);
+    actual_lhs(CADD_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CADD_H_S) = d_lhs;
+    expected_lhs(CADD_H_S) += d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs -= h_rhs;
-    actual_lhs(CSUB)   = cast_from_half<double>(tmp_lhs);
-    expected_lhs(CSUB) = d_lhs;
-    expected_lhs(CSUB) -= d_rhs;
+    actual_lhs(CSUB_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CSUB_H_H) = d_lhs;
+    expected_lhs(CSUB_H_H) -= d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs -= static_cast<float>(d_rhs);
+    actual_lhs(CSUB_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CSUB_H_S) = d_lhs;
+    expected_lhs(CSUB_H_S) -= d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs *= h_rhs;
-    actual_lhs(CMUL)   = cast_from_half<double>(tmp_lhs);
-    expected_lhs(CMUL) = d_lhs;
-    expected_lhs(CMUL) *= d_rhs;
+    actual_lhs(CMUL_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CMUL_H_H) = d_lhs;
+    expected_lhs(CMUL_H_H) *= d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs *= static_cast<float>(d_rhs);
+    actual_lhs(CMUL_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CMUL_H_S) = d_lhs;
+    expected_lhs(CMUL_H_S) *= d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs /= h_rhs;
-    actual_lhs(CDIV)   = cast_from_half<double>(tmp_lhs);
-    expected_lhs(CDIV) = d_lhs;
-    expected_lhs(CDIV) /= d_rhs;
+    actual_lhs(CDIV_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CDIV_H_H) = d_lhs;
+    expected_lhs(CDIV_H_H) /= d_rhs;
 
-    actual_lhs(ADD)   = cast_from_half<double>(h_lhs + h_rhs);
-    expected_lhs(ADD) = d_lhs + d_rhs;
+    tmp_lhs = h_lhs;
+    tmp_lhs /= static_cast<float>(d_rhs);
+    actual_lhs(CDIV_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CDIV_H_S) = d_lhs;
+    expected_lhs(CDIV_H_S) /= d_rhs;
 
-    actual_lhs(SUB)   = cast_from_half<double>(h_lhs - h_rhs);
-    expected_lhs(SUB) = d_lhs - d_rhs;
+    actual_lhs(ADD_H_H)   = cast_from_half<double>(h_lhs + h_rhs);
+    expected_lhs(ADD_H_H) = d_lhs + d_rhs;
+    actual_lhs(ADD_H_S) =
+        cast_from_half<double>(h_lhs + static_cast<float>(d_rhs));
+    expected_lhs(ADD_H_S) = d_lhs + d_rhs;
+    actual_lhs(ADD_S_H) =
+        cast_from_half<double>(static_cast<float>(d_lhs) + h_rhs);
+    expected_lhs(ADD_S_H) = d_lhs + d_rhs;
 
-    actual_lhs(MUL)   = cast_from_half<double>(h_lhs * h_rhs);
-    expected_lhs(MUL) = d_lhs * d_rhs;
+    actual_lhs(SUB_H_H)   = cast_from_half<double>(h_lhs - h_rhs);
+    expected_lhs(SUB_H_H) = d_lhs - d_rhs;
+    actual_lhs(SUB_H_S) =
+        cast_from_half<double>(h_lhs - static_cast<float>(d_rhs));
+    expected_lhs(SUB_H_S) = d_lhs - d_rhs;
+    actual_lhs(SUB_S_H) =
+        cast_from_half<double>(static_cast<float>(d_lhs) - h_rhs);
+    expected_lhs(SUB_S_H) = d_lhs - d_rhs;
 
-    actual_lhs(DIV)   = cast_from_half<double>(h_lhs / h_rhs);
-    expected_lhs(DIV) = d_lhs / d_rhs;
+    actual_lhs(MUL_H_H)   = cast_from_half<double>(h_lhs * h_rhs);
+    expected_lhs(MUL_H_H) = d_lhs * d_rhs;
+    actual_lhs(MUL_H_S) =
+        cast_from_half<double>(h_lhs * static_cast<float>(d_rhs));
+    expected_lhs(MUL_H_S) = d_lhs * d_rhs;
+    actual_lhs(MUL_S_H) =
+        cast_from_half<double>(static_cast<float>(d_lhs) * h_rhs);
+    expected_lhs(MUL_S_H) = d_lhs * d_rhs;
+
+    actual_lhs(DIV_H_H)   = cast_from_half<double>(h_lhs / h_rhs);
+    expected_lhs(DIV_H_H) = d_lhs / d_rhs;
+    actual_lhs(DIV_H_S) =
+        cast_from_half<double>(h_lhs / static_cast<float>(d_rhs));
+    expected_lhs(DIV_H_S) = d_lhs / d_rhs;
+    actual_lhs(DIV_S_H) =
+        cast_from_half<double>(static_cast<float>(d_lhs) / h_rhs);
+    expected_lhs(DIV_S_H) = d_lhs / d_rhs;
 
     actual_lhs(NEG)   = cast_from_half<double>(!h_lhs);
     expected_lhs(NEG) = !d_lhs;
@@ -228,13 +289,12 @@ struct Functor_TestHalfOperators {
     actual_lhs(PASS_BY_REF)   = cast_from_half<double>(accept_ref(h_lhs));
     expected_lhs(PASS_BY_REF) = d_lhs;
 
-    half_tmp = h_lhs;
-    // half_tmp = cast_from_half<float>(h_lhs);
-    tmp_ptr = &(tmp_lhs = half_tmp);
+    half_tmp = cast_from_half<float>(h_lhs);
+    tmp_ptr  = &(tmp_lhs = half_tmp);
     if (tmp_ptr != &tmp_lhs)
       Kokkos::abort("Error in half_t address-of operator");
-    actual_lhs(AO___HALF)   = cast_from_half<double>(*tmp_ptr);
-    expected_lhs(AO___HALF) = d_lhs;
+    actual_lhs(AO_IMPL_HALF)   = cast_from_half<double>(*tmp_ptr);
+    expected_lhs(AO_IMPL_HALF) = d_lhs;
 
     tmp2_lhs = h_lhs;
     tmp_ptr  = &(tmp_lhs = tmp2_lhs);
@@ -247,7 +307,7 @@ struct Functor_TestHalfOperators {
 
 void __test_half_operators(half_t h_lhs, half_t h_rhs) {
   double epsilon = half_is_float ? FLT_EPSILON : FP16_EPSILON;
-  Functor_TestHalfOperators<ViewType> f_device(h_lhs, h_rhs);    // Run on device
+  Functor_TestHalfOperators<ViewType> f_device(h_lhs, h_rhs);  // Run on device
   Functor_TestHalfOperators<ViewTypeHost> f_host(h_lhs, h_rhs);  // Run on host
   typename ViewType::HostMirror f_device_actual_lhs =
       Kokkos::create_mirror_view(f_device.actual_lhs);


### PR DESCRIPTION
Remove implicit conversion from half_t to __half and bool.
This may cause the compiler to consider all __half operators
or bool operators for expressions involving half_t.

Make operator{+,-,*,/} symmetric

Explicitly overload half_t constructors

Add casting to/from bool

Add test cases for symmetry

Do not force a copy constructor for half_t