### PR TITLE
half_t Cuda and deep_copy updates

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -134,8 +134,42 @@ class half_t {
   // Don't support implicit conversion back to impl_type.
   // impl_type is a storage only type on host.
   KOKKOS_FUNCTION
-  explicit operator impl_type() { return val; }
+  explicit operator impl_type() const { return val; }
+  KOKKOS_FUNCTION
+  explicit operator float() const { return cast_from_half<float>(*this); }
+  KOKKOS_FUNCTION
+  explicit operator bool() const { return cast_from_half<bool>(*this); }
+  KOKKOS_FUNCTION
+  explicit operator double() const { return cast_from_half<double>(*this); }
+  KOKKOS_FUNCTION
+  explicit operator short() const { return cast_from_half<short>(*this); }
+  KOKKOS_FUNCTION
+  explicit operator int() const { return cast_from_half<int>(*this); }
+  KOKKOS_FUNCTION
+  explicit operator long() const { return cast_from_half<long>(*this); }
+  KOKKOS_FUNCTION
+  explicit operator long long() const {
+    return cast_from_half<long long>(*this);
+  }
+  KOKKOS_FUNCTION
+  explicit operator unsigned short() const {
+    return cast_from_half<unsigned short>(*this);
+  }
+  KOKKOS_FUNCTION
+  explicit operator unsigned int() const {
+    return cast_from_half<unsigned int>(*this);
+  }
+  KOKKOS_FUNCTION
+  explicit operator unsigned long() const {
+    return cast_from_half<unsigned long>(*this);
+  }
+  KOKKOS_FUNCTION
+  explicit operator unsigned long long() const {
+    return cast_from_half<unsigned long long>(*this);
+  }
 
+  KOKKOS_FUNCTION
+  half_t(const half_t&) = default;
   KOKKOS_FUNCTION
   half_t(impl_type rhs) : val(rhs) {}
   KOKKOS_FUNCTION

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -292,6 +292,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
   ViewTypeB b;
 
   using policy_type = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>>;
+  using value_type  = typename ViewTypeA::value_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
@@ -301,7 +302,9 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const iType& i0) const { a(i0) = b(i0); };
+  void operator()(const iType& i0) const {
+    a(i0) = static_cast<value_type>(b(i0));
+  };
 };
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
@@ -317,6 +320,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
       Kokkos::Rank<2, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
       Kokkos::MDRangePolicy<ExecSpace, iterate_type, Kokkos::IndexType<iType>>;
+  using value_type = typename ViewTypeA::value_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
@@ -328,7 +332,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1) const {
-    a(i0, i1) = b(i0, i1);
+    a(i0, i1) = static_cast<value_type>(b(i0, i1));
   };
 };
 
@@ -346,6 +350,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
       Kokkos::Rank<3, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
       Kokkos::MDRangePolicy<ExecSpace, iterate_type, Kokkos::IndexType<iType>>;
+  using value_type = typename ViewTypeA::value_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
@@ -358,7 +363,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i2) const {
-    a(i0, i1, i2) = b(i0, i1, i2);
+    a(i0, i1, i2) = static_cast<value_type>(b(i0, i1, i2));
   };
 };
 


### PR DESCRIPTION
Half precision updates on Cuda

Add explicit conversion ops for casting from
half_t to supported types

Add copy constructor back to make half_t both
trivially and copy constructiblie

Update deep_copy use explicit cast

Use explicit casting to support deep_copy from T to half_t